### PR TITLE
ci: Add release.yml for changelog generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,31 @@
+# .github/release.yml
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - dependabot
+  categories:
+    - title: 💥 Breaking Changes
+      labels:
+        - breaking-change
+    - title: 🎉 New Features
+      labels:
+        - enhancement
+        - new-feature
+    - title: 🚀 Performance
+      labels:
+        - performance
+    - title: 🧠 Fiddling
+      labels:
+        - fiddling
+    - title: 🎮 Demos App
+      labels:
+        - demos
+    - title: 📄 Documentation
+      labels:
+        - documentation
+    - title: 💪 Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
- Added a new `release.yml` file to the `.github` directory.
- Configures the changelog generation for releases.
- Specifies labels to exclude from the changelog, such as `ignore-for-release` and contributions from `dependabot`.
- Categorizes the changelog into several sections